### PR TITLE
Update nodeSelectorTerms to use GPU product keys for an easier upgrade path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+* Changed nodeSelectorTerm on vllm deployments, for better upgradeability
+
 ## [0.1.1] - 2026-01-14
 
 * Added ArgoCD sync waves to LiteLLM to fix database migration timing (first installation)

--- a/applications/vllm/values.yaml
+++ b/applications/vllm/values.yaml
@@ -43,11 +43,11 @@ vllm:
               operator: "In"
               values:
                 - "true"
-            - key: kubernetes.io/hostname
+            - key: nvidia.com/gpu.product
               operator: "In"
               values:
                 # Send this to the large GPU node
-                - "gpu1"
+                - GRID-A100D-80C
 
       - name: "embeddings"
         repository: "vllm/vllm-openai"
@@ -91,11 +91,11 @@ vllm:
                 operator: "In"
                 values:
                   - "true"
-              - key: kubernetes.io/hostname
+              - key: nvidia.com/gpu.product
                 operator: "In"
                 values:
                   # Send this to the small GPU node
-                  - "gpu2"
+                  - GRID-A100D-20C
 
     vllmApiKey:
       secretName: "vllm-secret"


### PR DESCRIPTION
This lets us add new GPU nodes with newer Kubernetes-versions, but a different host-name for quicker Kubernetes-version-upgrades.