### PR TITLE
Fix OpenWebUI dashboard filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+### Fixed
+* Rename webui dashboard ConfigMap data key from `dcgm-dashboard.json` to `openwebui-dashboard.json` to avoid Grafana dashboard filename collisions. Fixes #11.
+
 ## [0.2.0] - 2026-02-25
 
 * Changed nodeSelectorTerm on vllm deployments, for better upgradeability

--- a/applications/prometheus-stack/templates/webui-dashboard.yaml
+++ b/applications/prometheus-stack/templates/webui-dashboard.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
      grafana_folder: "common"
 data:
-  dcgm-dashboard.json: |
+  openwebui-dashboard.json: |
     {{`
     {
       "annotations": {


### PR DESCRIPTION
Rename webui dashboard ConfigMap data key to openwebui-dashboard.json to avoid collisions. Fixes #11.