### PR TITLE
Allow ClusterRole and ClusterRoleBinding in cluster-resources AppProject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+### Changed
+
+* Allow `ClusterRole` and `ClusterRoleBinding` in the `cluster-resources` Argo CD AppProject so shared
+  cluster-scoped RBAC resources can be managed cleanly. See issue #21.
+
 ### Fixed
 
 * Rename webui dashboard ConfigMap data key from `dcgm-dashboard.json` to `openwebui-dashboard.json` to 

--- a/applications/argo-cd-resources/templates/projects/cluster-resources.yaml
+++ b/applications/argo-cd-resources/templates/projects/cluster-resources.yaml
@@ -10,6 +10,10 @@ spec:
   clusterResourceWhitelist:
   - group: storage.k8s.io
     kind: StorageClass
+  - group: rbac.authorization.k8s.io
+    kind: ClusterRole
+  - group: rbac.authorization.k8s.io
+    kind: ClusterRoleBinding
   orphanedResources:
     warn: false
   sourceRepos:


### PR DESCRIPTION
## Summary

This PR extends the `cluster-resources` Argo CD AppProject to allow cluster-scoped RBAC resources.

Closes #21

## Changes

- add `rbac.authorization.k8s.io/ClusterRole` to `spec.clusterResourceWhitelist`
- add `rbac.authorization.k8s.io/ClusterRoleBinding` to `spec.clusterResourceWhitelist`
- update `CHANGELOG.md`

## Why

The current `cluster-resources` AppProject only allows `StorageClass` as a cluster-scoped resource.

This prevents clean Argo-managed deployment of cluster-scoped RBAC resources needed for shared platform components such as Alloy log collection.

Without this change, local workarounds lead to:
- `SharedResourceWarning` on `AppProject/cluster-resources`
- `SyncError` for forbidden RBAC resources in the `cluster-resources` project

## Expected outcome

With this change, `cluster-resources` can manage:

- `StorageClass`
- `ClusterRole`
- `ClusterRoleBinding`

This enables a clean Argo-managed approach for shared cluster-scoped RBAC resources.